### PR TITLE
Adds react-native-picker/picker as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ For either platform, you can alternatively pass down a child element of your cho
 
 ### Installing
 
+This package is built around and depends on [@react-native-picker/picker](https://github.com/react-native-picker/picker). Please make sure you install it correctly (as seen below in installation steps).
+
 ```
 npm install react-native-picker-select
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "/src"
     ],
     "dependencies": {
-        "@react-native-picker/picker": "^1.8.3",
         "lodash.isequal": "^4.5.0"
     },
     "devDependencies": {
@@ -43,7 +42,11 @@
         "react": "16.6.1",
         "react-dom": "^16.6.1",
         "react-native": "0.57.7",
+        "@react-native-picker/picker": ">=2.1.0",
         "react-test-renderer": "^16.6.1"
+    },
+    "peerDependencies": {
+        "@react-native-picker/picker": ">=2.1.0"
     },
     "scripts": {
         "test": "jest",


### PR DESCRIPTION
Adds react-native-picker/picker as a peer dependency to prevent installing it multiple times. Will be used here https://github.com/Expensify/App/pull/7807#discussion_r818075309

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/203231
