### PR TITLE
Dismiss the keyboard when the picker opens on android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -532,6 +532,12 @@ export default class RNPickerSelect extends PureComponent {
                         onValueChange={this.onValueChange}
                         selectedValue={selectedItem.value}
                         {...pickerProps}
+                        onFocus={() => {
+                            Keyboard.dismiss();
+                            if (pickerProps.onFocus) {
+                                pickerProps.onFocus();
+                            }
+                        }}
                     >
                         {this.renderPickerItems()}
                     </Picker>
@@ -557,6 +563,12 @@ export default class RNPickerSelect extends PureComponent {
                     onValueChange={this.onValueChange}
                     selectedValue={selectedItem.value}
                     {...pickerProps}
+                    onFocus={() => {
+                        Keyboard.dismiss();
+                        if (pickerProps.onFocus) {
+                            pickerProps.onFocus();
+                        }
+                    }}
                 >
                     {this.renderPickerItems()}
                 </Picker>


### PR DESCRIPTION
Dismiss the soft keyboard when the picker opens on Android. This will align the behavior with the iOS platform.

Related Issue: https://github.com/Expensify/App/issues/15109

Upstream PR: https://github.com/lawnstarter/react-native-picker-select/pull/501