### PR TITLE
Fixed the mweb safari popup picker cannot be full screen when the keyboard is displayed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -546,10 +546,10 @@ export default class RNPickerSelect extends PureComponent {
                     selectedValue={selectedItem.value}
                     {...pickerProps}
                     onPointerUp={(event) => {
-                    	Keyboard.dismiss();
-                    	if (pickerProps.onPointerUp) {
-                    		pickerProps.onPointerUp(event);
-                    	}
+                        Keyboard.dismiss();
+                        if (pickerProps.onPointerUp) {
+                            pickerProps.onPointerUp(event);
+                        }
                     }}
                 >
                     {this.renderPickerItems()}

--- a/src/index.js
+++ b/src/index.js
@@ -545,6 +545,12 @@ export default class RNPickerSelect extends PureComponent {
                     onValueChange={this.onValueChange}
                     selectedValue={selectedItem.value}
                     {...pickerProps}
+                    onPointerUp={(event) => {
+                    	Keyboard.dismiss();
+                    	if (pickerProps.onPointerUp) {
+                    		pickerProps.onPointerUp(event);
+                    	}
+                    }}
                 >
                     {this.renderPickerItems()}
                 </Picker>


### PR DESCRIPTION
Issue: https://github.com/Expensify/App/issues/16081
Proposal: https://github.com/Expensify/App/issues/16081#issuecomment-1477345252
C+ Review: https://github.com/Expensify/App/issues/16081#issuecomment-1480384179
Expensify Review: https://github.com/Expensify/App/issues/16081#issuecomment-1494824244

When the keyboard is displayed, mwebSafari pops up a new picker and cannot calculate the correct screen height, causing the picker to not be full screen

We `dismiss` the keyboard in the `onPointerUp` first, and then the page can correctly display the size of the picker