### PR TITLE
Implement PickerAvoidingView and PickerStateProvider

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -92,3 +92,11 @@ declare class Picker extends React.Component<PickerSelectProps> {
 }
 
 export default Picker;
+
+type PickerStateProviderProps = {
+    readonly children: React.ReactChild;
+};
+
+export const PickerStateProvider: React.ComponentType<PickerStateProviderProps>;
+
+export const PickerAvoidingView: React.ComponentType<React.PropsWithChildren>;

--- a/src/PickerAvoidingView/index.ios.js
+++ b/src/PickerAvoidingView/index.ios.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { PickerStateContext } from '../PickerStateProvider';
 import { IOS_MODAL_HEIGHT } from '../constants';
+import PropTypes from 'prop-types';
 
 /**
  * PickerAvoidingView is a React component that adjusts the view layout to avoid
@@ -16,12 +17,17 @@ import { IOS_MODAL_HEIGHT } from '../constants';
  * protected from obstruction by the picker modal
  */
 export class PickerAvoidingView extends Component {
+    static propTypes = {
+        enabled: PropTypes.bool,
+    };
+
     static defaultProps = {
         enabled: true,
     };
 
     render() {
-        const { enabled, style, children, ...otherProps } = this.props;
+        const { enabled, style, ...viewProps } = this.props;
+
         return (
             <PickerStateContext.Consumer>
                 {(context) => {
@@ -32,11 +38,7 @@ export class PickerAvoidingView extends Component {
                           })
                         : style;
 
-                    return (
-                        <View style={effectiveStyle} {...otherProps}>
-                            {children}
-                        </View>
-                    );
+                    return <View style={effectiveStyle} {...viewProps} />;
                 }}
             </PickerStateContext.Consumer>
         );

--- a/src/PickerAvoidingView/index.ios.js
+++ b/src/PickerAvoidingView/index.ios.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { PickerStateContext } from '../PickerStateProvider';
+import { IOS_MODAL_HEIGHT } from '../constants';
+
+/**
+ * PickerAvoidingView is a React component that adjusts the view layout to avoid
+ * being covered by an open iOS picker modal. It's meant to be similar to
+ * the built-in KeyboardAvoidingView component, but specifically tailored for
+ * iOS picker modals.
+ *
+ * In order for this component to work correctly, all the pickers and the
+ * PickerAvoidingView should have a PickerStateProvider ancestor.
+ *
+ * @param {React.ReactNode} props.children - The child components that should be
+ * protected from obstruction by the picker modal
+ */
+export class PickerAvoidingView extends Component {
+    static defaultProps = {
+        enabled: true,
+    };
+
+    render() {
+        const { enabled, style, children, ...otherProps } = this.props;
+        return (
+            <PickerStateContext.Consumer>
+                {(context) => {
+                    const isModalShown = context && context.isModalShown;
+                    const effectiveStyle = enabled
+                        ? StyleSheet.compose(style, {
+                              paddingBottom: isModalShown ? IOS_MODAL_HEIGHT : 0,
+                          })
+                        : style;
+
+                    return (
+                        <View style={effectiveStyle} {...otherProps}>
+                            {children}
+                        </View>
+                    );
+                }}
+            </PickerStateContext.Consumer>
+        );
+    }
+}

--- a/src/PickerAvoidingView/index.js
+++ b/src/PickerAvoidingView/index.js
@@ -11,5 +11,5 @@ import { View } from 'react-native';
 export function PickerAvoidingView(props) {
     // eslint-disable-next-line no-unused-vars
     const { enabled, ...viewProps } = props;
-    return <View {...viewProps}>{props.children}</View>;
+    return <View {...viewProps} />;
 }

--- a/src/PickerAvoidingView/index.js
+++ b/src/PickerAvoidingView/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View } from 'react-native';
+
+/**
+ * As, currently, only on iOS the picker's modal resembles the software keyboard
+ * in any way, the default implementation doesn't have any avoiding logic.
+ *
+ * @param {React.ReactNode} props.children - The child components to render
+ * within the PickerAvoidingView.
+ */
+export function PickerAvoidingView(props) {
+    // eslint-disable-next-line no-unused-vars
+    const { enabled, ...viewProps } = props;
+    return <View {...viewProps}>{props.children}</View>;
+}

--- a/src/PickerStateProvider.js
+++ b/src/PickerStateProvider.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+/**
+ * @typedef {Object} PickerStateData
+ * @property {boolean} isModalOpen - Indicates whether a picker-related modal is
+ * currently being shown. Note that currently modal is opened for pickers only
+ * on iOS.
+ *
+ * PickerStateContext is a context that gives access to PickerStateData.
+ */
+export const PickerStateContext = React.createContext();
+
+/**
+ * PickerStateProvider provides PickerStateContext and manages the necessary
+ * state.
+ *
+ * This component should be used as a single top-level provider for all picker
+ * instances in your application.
+ */
+export class PickerStateProvider extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isModalShown: false,
+        };
+    }
+
+    render() {
+        const context = {
+            isModalShown: this.state.isModalShown,
+            setIsModalShown: (isModalShown) => {
+                this.setState({ isModalShown });
+            },
+        };
+
+        return (
+            <PickerStateContext.Provider value={context}>
+                {this.props.children}
+            </PickerStateContext.Provider>
+        );
+    }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,3 @@
+// Measuring the modal before rendering is not working reliably, so we need to hardcode the height
+// This height was tested thoroughly on several iPhone models (iPhone SE, from iPhone 8 to 14 Pro, and 14 Pro Max)
+export const IOS_MODAL_HEIGHT = 262;


### PR DESCRIPTION
...which provide tools for ensuring that a picker is not covered by its own modal on iOS.

I'm still testing these changes, but they are ready to be reviewed, as I don't expect any major changes in the approach for now.