### PR TITLE
Implement keyboardDidHide listener and open modal if the Keyboard appears

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -291,13 +291,12 @@ export default class RNPickerSelect extends PureComponent {
 
         if (Keyboard.isVisible()) {
             const keyboardListener = Keyboard.addListener('keyboardDidHide', () => {
-               this.updatePickerState(animate,postToggleCallback);
+               this.updatePickerState(animate, postToggleCallback);
                keyboardListener.remove();
             });
             Keyboard.dismiss();
-        }
-        else {
-            this.updatePickerState(animate,postToggleCallback);
+        } else {
+            this.updatePickerState(animate, postToggleCallback);
         }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,9 @@ import { Dimensions } from 'react-native';
 // This height was tested thoroughly on several iPhone Models (from iPhone 8 to 14 Pro)
 const IOS_MODAL_HEIGHT = 262;
 
-const preserveSpaces = (label) =>  {
+const preserveSpaces = (label) => {
     return label.replace(/ /g, '\u00a0');
- }
+};
 
 export default class RNPickerSelect extends PureComponent {
     static propTypes = {
@@ -282,7 +282,7 @@ export default class RNPickerSelect extends PureComponent {
                 }
             }
         );
-    }
+    };
 
     togglePicker(animate = false, postToggleCallback) {
         const { disabled } = this.props;
@@ -295,8 +295,8 @@ export default class RNPickerSelect extends PureComponent {
 
         if (Keyboard.isVisible()) {
             const keyboardListener = Keyboard.addListener('keyboardDidHide', () => {
-               this.updatePickerState(animate, postToggleCallback);
-               keyboardListener.remove();
+                this.updatePickerState(animate, postToggleCallback);
+                keyboardListener.remove();
             });
             Keyboard.dismiss();
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,7 @@ export default class RNPickerSelect extends PureComponent {
         this.scrollToInput = this.scrollToInput.bind(this);
         this.togglePicker = this.togglePicker.bind(this);
         this.renderInputAccessoryView = this.renderInputAccessoryView.bind(this);
+        this.updatePickerState = this.updatePickerState.bind(this);
     }
 
     componentDidUpdate = (prevProps, prevState) => {
@@ -260,23 +261,10 @@ export default class RNPickerSelect extends PureComponent {
         }
     }
 
-    togglePicker(animate = false, postToggleCallback) {
-        const { modalProps, disabled } = this.props;
-        const { showPicker } = this.state;
-
-        if (disabled) {
-            return;
-        }
-
-        if (!showPicker) {
-            Keyboard.dismiss();
-        }
-
+    updatePickerState = (animate = false, postToggleCallback) => {
+        const { modalProps } = this.props;
         const animationType =
             modalProps && modalProps.animationType ? modalProps.animationType : 'slide';
-
-        this.triggerOpenCloseCallbacks();
-
         this.setState(
             (prevState) => {
                 return {
@@ -290,6 +278,27 @@ export default class RNPickerSelect extends PureComponent {
                 }
             }
         );
+    }
+
+    togglePicker(animate = false, postToggleCallback) {
+        const { disabled } = this.props;
+
+        if (disabled) {
+            return;
+        }
+
+        this.triggerOpenCloseCallbacks();
+
+        if (Keyboard.isVisible()) {
+            const keyboardListener = Keyboard.addListener('keyboardDidHide', () => {
+               this.updatePickerState(animate,postToggleCallback);
+               keyboardListener.remove();
+            });
+            Keyboard.dismiss();
+        }
+        else {
+            this.updatePickerState(animate,postToggleCallback);
+        }
     }
 
     renderPickerItems() {

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,8 @@ describe('RNPickerSelect', () => {
     beforeEach(() => {
         jest.resetAllMocks();
         jest.spyOn(Keyboard, 'dismiss');
+        jest.spyOn(Keyboard, 'addListener');
+        Keyboard.isVisible = jest.fn().mockReturnValue(false);
     });
 
     describe('when provided an itemKey prop', () => {
@@ -142,6 +144,25 @@ describe('RNPickerSelect', () => {
         const touchable = wrapper.find('TouchableOpacity').at(1);
         touchable.simulate('press');
         expect(wrapper.state().showPicker).toEqual(true);
+    });
+
+    it('should call Keyboard.addListener when keyboard is visible', () => {
+        Keyboard.isVisible.mockReturnValue(true);
+        const wrapper = shallow(<RNPickerSelect items={selectItems} onValueChange={noop} />);
+
+        const touchable = wrapper.find('TouchableOpacity').at(1);
+        touchable.simulate('press');
+        expect(Keyboard.addListener).toHaveBeenCalledTimes(1);
+        expect(Keyboard.addListener).toHaveBeenCalledWith('keyboardDidHide', expect.any(Function));
+    });
+
+    it('should not call Keyboard.addListener when keyboard is not visible', () => {
+        Keyboard.isVisible.mockReturnValue(false);
+        const wrapper = shallow(<RNPickerSelect items={selectItems} onValueChange={noop} />);
+
+        const touchable = wrapper.find('TouchableOpacity').at(1);
+        touchable.simulate('press');
+        expect(Keyboard.addListener).not.toHaveBeenCalled();
     });
 
     it('should not show the picker when pressed if disabled', () => {
@@ -245,6 +266,7 @@ describe('RNPickerSelect', () => {
     });
 
     it('should call Keyboard.dismiss when opened', () => {
+        Keyboard.isVisible.mockReturnValue(true);
         const wrapper = shallow(<RNPickerSelect items={selectItems} onValueChange={noop} />);
 
         const touchable = wrapper.find('[testID="ios_touchable_wrapper"]');


### PR DESCRIPTION
Original issue: $https://github.com/Expensify/App/issues/16353

This PR changes implementation on Keyboard dismiss inside `togglePicker` method.  In current implementation `Keyboard.dismiss()` is called immediately, which can caused issues ( eg.  https://github.com/Expensify/App/issues/16353). 
I added listener `keyboardDidHide` and open modal if the Keyboard appears. Otherwise just open modal.