### PR TITLE
Add `PickerAvoidingView` and `PickerStateProvider` for better iOS modal handling

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -92,3 +92,11 @@ declare class Picker extends React.Component<PickerSelectProps> {
 }
 
 export default Picker;
+
+type PickerStateProviderProps = {
+    readonly children: React.ReactChild;
+};
+
+export const PickerStateProvider: React.ComponentType<PickerStateProviderProps>;
+
+export const PickerAvoidingView: React.ComponentType<React.PropsWithChildren>;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "lodash.isequal": "^4.5.0"
     },
     "devDependencies": {
+        "@react-native-picker/picker": ">=2.1.0",
         "@types/react-native": "^0.60.22",
         "babel-jest": "^23.6.0",
         "babel-preset-react-native": "^4.0.1",

--- a/src/PickerAvoidingView/index.ios.js
+++ b/src/PickerAvoidingView/index.ios.js
@@ -37,13 +37,15 @@ export function PickerAvoidingView(props) {
         }
     }, [isPickerOpen]);
 
-    return (
-        <View
-            style={StyleSheet.compose(props.style, {
-                paddingBottom: shouldAddSpace ? IOS_MODAL_HEIGHT : 0,
-            })}
-        >
-            {props.children}
-        </View>
-    );
+    const style = props.enabled
+        ? StyleSheet.compose(props.style, {
+              paddingBottom: shouldAddSpace ? IOS_MODAL_HEIGHT : 0,
+          })
+        : props.style;
+
+    return <View style={style}>{props.children}</View>;
 }
+
+PickerAvoidingView.defaultProps = {
+    enabled: true,
+};

--- a/src/PickerAvoidingView/index.ios.js
+++ b/src/PickerAvoidingView/index.ios.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { PickerStateContext } from "../PickerStateProvider";
-import { IOS_MODAL_HEIGHT } from "../constants";
+import { PickerStateContext } from '../PickerStateProvider';
+import { IOS_MODAL_ANIMATION_DURATION_MS, IOS_MODAL_HEIGHT } from '../constants';
+
+function schedule(callback, timeout) {
+    const handle = setTimeout(callback, timeout);
+    return () => clearTimeout(handle);
+}
 
 /**
  * PickerAvoidingView is a React component that adjusts the view layout to avoid
@@ -19,10 +24,25 @@ export function PickerAvoidingView(props) {
     const context = React.useContext(PickerStateContext);
     const isPickerOpen = context && context.isPickerOpen;
 
+    const [shouldAddSpace, setShouldAddSpace] = React.useState(false);
+
+    React.useEffect(() => {
+        if (isPickerOpen) {
+            // Add a delay, as adding the padding before the modal fully expanded gives a visually unpleasant effect
+            return schedule(() => {
+                setShouldAddSpace(true);
+            }, IOS_MODAL_ANIMATION_DURATION_MS);
+        } else {
+            setShouldAddSpace(false);
+        }
+    }, [isPickerOpen]);
+
     return (
-        <View style={StyleSheet.compose(props.style, {
-            paddingBottom: isPickerOpen ? IOS_MODAL_HEIGHT : 0,
-        })}>
+        <View
+            style={StyleSheet.compose(props.style, {
+                paddingBottom: shouldAddSpace ? IOS_MODAL_HEIGHT : 0,
+            })}
+        >
             {props.children}
         </View>
     );

--- a/src/PickerAvoidingView/index.ios.js
+++ b/src/PickerAvoidingView/index.ios.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { PickerStateContext } from "../PickerStateProvider";
+import { IOS_MODAL_HEIGHT } from "../constants";
+
+/**
+ * PickerAvoidingView is a React component that adjusts the view layout to avoid
+ * being covered by an open iOS UIPickerView modal. It's meant to be similar to
+ * the built-in KeyboardAvoidingView component, but specifically tailored for
+ * iOS picker modals.
+ *
+ * In order for this component to work correctly, all the pickers and the
+ * PickerAvoidingView should have a PickerStateProvider ancestor.
+ *
+ * @param {React.ReactNode} props.children - The child components that should be
+ * protected from obstruction by the picker modal
+ */
+export function PickerAvoidingView(props) {
+    const context = React.useContext(PickerStateContext);
+    const isPickerOpen = context && context.isPickerOpen;
+
+    return (
+        <View style={StyleSheet.compose(props.style, {
+            paddingBottom: isPickerOpen ? IOS_MODAL_HEIGHT : 0,
+        })}>
+            {props.children}
+        </View>
+    );
+}

--- a/src/PickerAvoidingView/index.js
+++ b/src/PickerAvoidingView/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View } from "react-native";
+
+/**
+ * As, currently, only on iOS the picker's modal resembles the software keyboard
+ * in any way, the default implementation doesn't have any avoiding logic.
+ *
+ * @param {React.ReactNode} props.children - The child components to render
+ * within the PickerAvoidingView.
+ */
+export function PickerAvoidingView(props) {
+    return <View {...props}>{props.children}</View>;
+}

--- a/src/PickerAvoidingView/index.js
+++ b/src/PickerAvoidingView/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from "react-native";
+import { View } from 'react-native';
 
 /**
  * As, currently, only on iOS the picker's modal resembles the software keyboard
@@ -9,5 +9,7 @@ import { View } from "react-native";
  * within the PickerAvoidingView.
  */
 export function PickerAvoidingView(props) {
-    return <View {...props}>{props.children}</View>;
+    // eslint-disable-next-line no-unused-vars
+    const { enabled, ...viewProps } = props;
+    return <View {...viewProps}>{props.children}</View>;
 }

--- a/src/PickerStateProvider.js
+++ b/src/PickerStateProvider.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+/**
+ * @typedef {Object} PickerStateData
+ * @property {boolean} isPickerOpen - Indicates whether any picker is currently open
+ *
+ * PickerStateContext is a context that gives access to PickerStateData.
+ */
+export const PickerStateContext = React.createContext();
+
+/**
+ * PickerStateProvider provides PickerStateContext and manages the necessary
+ * state.
+ *
+ * This component should be used as a single top-level provider for all picker
+ * instances in your application.
+ */
+export function PickerStateProvider(props) {
+    const [isPickerOpen, setIsPickerOpen] = React.useState(false);
+
+    const context = {
+        isPickerOpen,
+        setIsPickerOpen,
+    };
+
+    return (
+        <PickerStateContext.Provider value={context}>
+            {props.children}
+        </PickerStateContext.Provider>
+    );
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,3 @@
+// Measuring the modal before rendering is not working reliably, so we need to hardcode the height
+// This height was tested thoroughly on several iPhone models (iPhone SE, from iPhone 8 to 14 Pro, and 14 Pro Max)
+export const IOS_MODAL_HEIGHT = 262;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,6 @@
 // Measuring the modal before rendering is not working reliably, so we need to hardcode the height
 // This height was tested thoroughly on several iPhone models (iPhone SE, from iPhone 8 to 14 Pro, and 14 Pro Max)
 export const IOS_MODAL_HEIGHT = 262;
+
+// An approximated duration of the modal opening
+export const IOS_MODAL_ANIMATION_DURATION_MS = 500;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,21 @@
 import React, { PureComponent } from 'react';
-import { Keyboard, Modal, Platform, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import {
+    Dimensions,
+    Keyboard,
+    Modal,
+    Platform,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from 'react-native';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 import { Picker } from '@react-native-picker/picker';
 import { defaultStyles } from './styles';
-import { Dimensions } from 'react-native';
 import { PickerAvoidingView } from './PickerAvoidingView';
 import { PickerStateContext, PickerStateProvider } from './PickerStateProvider';
-import { IOS_MODAL_HEIGHT } from './constants';
+import { IOS_MODAL_ANIMATION_DURATION_MS, IOS_MODAL_HEIGHT } from './constants';
 
 export default class RNPickerSelect extends PureComponent {
     static contextType = PickerStateContext;
@@ -240,9 +248,13 @@ export default class RNPickerSelect extends PureComponent {
 
             // If TextInput is below picker modal, scroll up
             if (textInputBottomY > modalY) {
-                this.props.scrollViewRef.current.scrollTo({
-                    y: textInputBottomY - modalY + this.props.scrollViewContentOffsetY,
-                });
+                // Wait until the modal animation finishes, so the scrolling is effective when PickerAvoidingView is
+                // used
+                setTimeout(() => {
+                    this.props.scrollViewRef.current.scrollTo({
+                        y: textInputBottomY - modalY + 10 + this.props.scrollViewContentOffsetY,
+                    });
+                }, IOS_MODAL_ANIMATION_DURATION_MS + 50);
             }
         });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,13 @@ import isEqual from 'lodash.isequal';
 import { Picker } from '@react-native-picker/picker';
 import { defaultStyles } from './styles';
 import { Dimensions } from 'react-native';
-
-// Measuring the modal before rendering is not working reliably, so we need to hardcode the height
-// This height was tested thoroughly on several iPhone Models (from iPhone 8 to 14 Pro)
-const IOS_MODAL_HEIGHT = 262;
+import { PickerAvoidingView } from './PickerAvoidingView';
+import { PickerStateContext, PickerStateProvider } from './PickerStateProvider';
+import { IOS_MODAL_HEIGHT } from './constants';
 
 export default class RNPickerSelect extends PureComponent {
+    static contextType = PickerStateContext;
+
     static propTypes = {
         onValueChange: PropTypes.func.isRequired,
         items: PropTypes.arrayOf(
@@ -274,6 +275,10 @@ export default class RNPickerSelect extends PureComponent {
 
         const animationType =
             modalProps && modalProps.animationType ? modalProps.animationType : 'slide';
+
+        if (this.context) {
+            this.context.setIsPickerOpen(!showPicker);
+        }
 
         this.triggerOpenCloseCallbacks();
 
@@ -605,4 +610,4 @@ export default class RNPickerSelect extends PureComponent {
     }
 }
 
-export { defaultStyles };
+export { defaultStyles, PickerStateProvider, PickerAvoidingView };

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,10 +780,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@react-native-picker/picker@^1.8.3":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.8.3.tgz#fcbf969a4add749fc37ef064a5eb55eadc93db39"
-  integrity sha512-zfr8k9L5BJVN7fIrmrto1cCptZjkGoiKWeZTsCR+XormQnWj0Tqrv0S9Ni3SvdT5JZ2OAQ9H+edMRSUvrAxwQA==
+"@react-native-picker/picker@>=2.1.0":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.8.tgz#a1a21f3d6ecadedbc3f0b691a444ddd7baa081f8"
+  integrity sha512-5NQ5XPo1B03YNqKFrV6h9L3CQaHlB80wd4ETHUEABRP2iLh7FHLVObX2GfziD+K/VJb8G4KZcZ23NFBFP1f7bg==
 
 "@types/minimatch@^3.0.3":
   version "3.0.3"


### PR DESCRIPTION
This PR introduces two new components, `PickerAvoidingView` and `PickerStateProvider`. These components aim to improve the user experience on iOS by ensuring that the picker is not obstructed by its own modal. The PickerAvoidingView handles proper positioning of the picker, while the PickerStateProvider manages the state and interactions between multiple pickers. This update enhances the overall usability of the picker component on iOS devices.

Note: This PR is stacked on top of https://github.com/lawnstarter/react-native-picker-select/pull/496, so that one needs to be merged first