### PR TITLE
Add `pointerEvents={"none"}` to the `TextInput`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -443,6 +443,7 @@ export default class RNPickerSelect extends PureComponent {
             <View pointerEvents="box-only" style={containerStyle}>
                 <TextInput
                     testID="text_input"
+                    pointerEvents="none"
                     style={[
                         Platform.OS === 'ios' ? style.inputIOS : style.inputAndroid,
                         this.getPlaceholderStyle(),


### PR DESCRIPTION
On the new architecture the `TextInput` used to display the text was intercepting events. This seems to be caused by the [view-flattening algorithm](https://reactnative.dev/architecture/view-flattening) moving it out of the parent view which has `pointerEvents="box-only"` set.

The solution would be either to add `pointerEvents="none"` to the `TextInput` itself, as done in this PR, or to disable the view flattening for the parent view (by adding `collapsable={false}` prop to it), so the native view structure would match the react one.

Let me know if you prefer the second approach and I will update the PR.