### PR TITLE
Fix picker still avoiding view when the picker itself is unmounted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -181,6 +181,12 @@ export default class RNPickerSelect extends PureComponent {
         }
     };
 
+    componentWillUnmount() {
+        if (this.context) {
+            this.context.setIsModalShown(false);
+        }
+    }
+
     onUpArrow() {
         const { onUpArrow } = this.props;
 


### PR DESCRIPTION
**Description**
PickerAvoidingView is added in [this](https://github.com/Expensify/react-native-picker-select/pull/8) PR to make sure the input that triggers the picker is not covered by the picker modal itself, similar to what KeyboardAvoidingView is doing.

It works by maintaining the picker modal visibility state in a context. However, the handling of the state does not take into account if the picker itself is unmounted from the screen resulting in the visibility state being stuck at `true`.

**Test plan**
Use this branch/commit and test if the issue at https://github.com/Expensify/App/issues/23044 is resolved.

Test step:
1. Open Settings > Workspaces > Select any workspace > Bank Account
2. Complete the first step
3. On the 2nd step, find any field with a picker, for example, State, and press it to show the picker.
4. Put the app to background
5. Open the app back
6. Notice that going back to the app will show a loading screen for a while. After the loading completes, verify the 2nd step shows back
7. Verify the page is not cut off

https://github.com/Expensify/react-native-picker-select/assets/50919443/9b88c417-521d-4b46-8b61-3936fb94bfa0

