### PR TITLE
[TS migration] Update CustomPickerProps and Icon types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,7 +99,6 @@ export interface PickerSelectProps {
 
 declare class Picker extends React.Component<PickerSelectProps> {
     togglePicker: (animate?: boolean, postToggleCallback?: () => void) => void;
-
     focus: () => void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,7 +56,9 @@ type CustomModalProps = Omit<ModalProps, 'visible' | 'transparent' | 'animationT
 type CustomTextInputProps = Omit<TextInputProps, 'style' | 'value' | 'ref' | 'editable'>;
 // 'testID' is also used, but can be overwritten safely
 
-type CustomPickerProps = Omit<PickerProps, 'onValueChange' | 'selectedValue'>;
+type CustomPickerProps = Omit<PickerProps, 'onValueChange' | 'selectedValue'> & {
+    ref?: React.RefObject<Picker>;
+};
 // 'style' and 'enabled' are also used, but only in headless or native Android mode
 // 'testID' is also used, but can be overwritten safely
 
@@ -88,7 +90,7 @@ export interface PickerSelectProps {
     pickerProps?: CustomPickerProps;
     touchableDoneProps?: CustomTouchableDoneProps;
     touchableWrapperProps?: CustomTouchableWrapperProps;
-    Icon?: React.ReactNode;
+    Icon?: React.ComponentType;
     InputAccessoryView?: React.ReactNode;
     scrollViewRef?: React.RefObject<ScrollView>;
     scrollViewContentOffsetY?: number;
@@ -97,6 +99,8 @@ export interface PickerSelectProps {
 
 declare class Picker extends React.Component<PickerSelectProps> {
     togglePicker: (animate?: boolean, postToggleCallback?: () => void) => void;
+
+    focus: () => void;
 }
 
 export default Picker;


### PR DESCRIPTION
### Description
The lack of Picker typing was noticed during the Expensify app [Picker migration](https://github.com/Expensify/App/pull/30646) to the TypeScript. This PR resolve the TS issues that was defined during the Picker migration:

- [Icon type issue](https://github.com/Expensify/App/pull/30646/files#diff-8f7f186dddc1634b444dc0e396eaf9b96c2c369ed3c30fdf8007d4ebb51685bcR168)
- [Ref issue](https://github.com/Expensify/App/pull/30646/files#diff-8f7f186dddc1634b444dc0e396eaf9b96c2c369ed3c30fdf8007d4ebb51685bcR178)

### Related Issues
$ https://github.com/Expensify/App/issues/25091