### PR TITLE
Fix props type for PickerAvoidingView

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,9 @@ import {
     TextStyle,
     TouchableOpacityProps,
     ViewStyle,
+    ViewProps,
 } from 'react-native';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { PickerProps } from '@react-native-picker/picker/typings/Picker';
 
 export interface Item {
@@ -110,4 +111,6 @@ type PickerStateProviderProps = {
 
 export const PickerStateProvider: React.ComponentType<PickerStateProviderProps>;
 
-export const PickerAvoidingView: React.ComponentType<React.PropsWithChildren>;
+type PickerAvoidingViewProps = ViewProps & { enabled?: boolean; children?: ReactNode };
+
+export const PickerAvoidingView: React.ComponentType<PickerAvoidingViewProps>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ import {
     ViewStyle,
     ViewProps,
 } from 'react-native';
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { PickerProps } from '@react-native-picker/picker/typings/Picker';
 
 export interface Item {
@@ -111,6 +111,6 @@ type PickerStateProviderProps = {
 
 export const PickerStateProvider: React.ComponentType<PickerStateProviderProps>;
 
-type PickerAvoidingViewProps = ViewProps & { enabled?: boolean; children?: ReactNode };
+type PickerAvoidingViewProps = ViewProps & { enabled?: boolean };
 
 export const PickerAvoidingView: React.ComponentType<PickerAvoidingViewProps>;


### PR DESCRIPTION
This PR originated from https://github.com/Expensify/App/pull/33870, where `PickerAvoidingView` is used.