### PR TITLE
[No QA] [TS migration] children type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ declare class Picker extends React.Component<PickerSelectProps> {
 export default Picker;
 
 type PickerStateProviderProps = {
-    readonly children: React.ReactChild;
+    readonly children: React.ReactNode;
 };
 
 export const PickerStateProvider: React.ComponentType<PickerStateProviderProps>;


### PR DESCRIPTION
Replace deprecated `React.ReactChild` with `React.ReactNode` for children propType

Came from https://github.com/Expensify/App/pull/35242#discussion_r1467698532

cc: @mountiny
sorry for the ping but not able to tag other folks