### PR TITLE
[RN 0.79] Fix ref type to comply with React 19

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ type CustomTextInputProps = Omit<TextInputProps, 'style' | 'value' | 'ref' | 'ed
 // 'testID' is also used, but can be overwritten safely
 
 type CustomPickerProps = Omit<PickerProps, 'onValueChange' | 'selectedValue'> & {
-    ref?: React.RefObject<Picker>;
+    ref?: React.Ref<Picker>;
 };
 // 'style' and 'enabled' are also used, but only in headless or native Android mode
 // 'testID' is also used, but can be overwritten safely


### PR DESCRIPTION
React 19 enforces the use of an initial value in each `useRef`, which caused a type error in `src/components/Picker/BasePicker.tsx`. This can be easily fixed by adjusting the library's type.

$ https://github.com/Expensify/App/issues/57511