### PR TITLE
Fix unsafe mutable references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Autoclose issues that did not follow issue template
-      uses: roots/issue-closer@v1.1
+      uses: roots/issue-closer@95665902c8ad8808e378371ef57fbedbf99ba744 # v1.1
       with:
         repo-token: ${{ secrets.GH_TOKEN }}
         issue-close-message: "@${issue.user.login} this issue was automatically closed because it did not follow one of the available issue templates. See [here](https://github.com/lawnstarter/react-native-picker-select/issues/new/choose) for available options."


### PR DESCRIPTION
Pin roots/issue-closer-action GitHub Action from the mutable v1.1 tag to the immutable commit `95665902c8ad8808e378371ef57fbedbf99ba744` to satisfy workflow security validation. See [here](https://github.com/roots/issue-closer-action/releases/tag/v1.1).



Pre-requisite to https://github.com/Expensify/react-native-picker-select/pull/19