### PR TITLE
Correctly spread touchableDoneProps 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -438,9 +438,9 @@ export default class RNPickerSelect extends PureComponent {
             bottom: 4,
             left: 4,
           }}
-          {...touchableDoneProps}
           accessibilityRole="button"
           accessibilityLabel={doneText}
+          {...touchableDoneProps}
         >
           <View testID="needed_for_touchable">
             <Text


### PR DESCRIPTION
The prop was spread in the middle, so accessibilityLabel and accessibilityRole were not being overriden.

Fixes: https://github.com/Expensify/App/issues/77534